### PR TITLE
Адаптировано для Нартис И100-W112

### DIFF
--- a/components/dlms_cosem/dlms_cosem.cpp
+++ b/components/dlms_cosem/dlms_cosem.cpp
@@ -315,8 +315,6 @@ void DlmsCosemComponent::loop() {
       this->stats_.connections_tried_++;
       session_started_ms = millis();
       this->log_state_();
-      this->has_error = false;
-      
       this->clear_rx_buffers_();
       request_iter = this->sensors_.begin();
 

--- a/components/dlms_cosem/dlms_cosem.cpp
+++ b/components/dlms_cosem/dlms_cosem.cpp
@@ -108,7 +108,7 @@ void DlmsCosemComponent::set_baud_rate_(uint32_t baud_rate) {
   iuart_->update_baudrate(baud_rate);
 }
 
-void DlmsCosemComponent::update_server_address(uint16_t logicalAddress, uint16_t physicalAddress, unsigned char addressSize) {
+uint16_t DlmsCosemComponent::update_server_address(uint16_t logicalAddress, uint16_t physicalAddress, unsigned char addressSize) {
   uint16_t value;
   if (addressSize < 4 && physicalAddress < 0x80 && logicalAddress < 0x80)
   {
@@ -129,6 +129,8 @@ void DlmsCosemComponent::update_server_address(uint16_t logicalAddress, uint16_t
             this->auth_required_ ? this->password_.c_str() : NULL, DLMS_INTERFACE_TYPE_HDLC);  
 
   this->set_next_state_delayed_(2000, State::OPEN_SESSION);
+
+  return value
 }
 
 void DlmsCosemComponent::setup() {

--- a/components/dlms_cosem/dlms_cosem.cpp
+++ b/components/dlms_cosem/dlms_cosem.cpp
@@ -239,7 +239,7 @@ void DlmsCosemComponent::loop() {
 
       if (this->check_rx_timeout_()) {
         ESP_LOGE(TAG, "RX timeout.");
-        this->has_errors = true;
+        this->has_error = true;
         this->dlms_reading_state_.last_error = DLMS_ERROR_CODE_HARDWARE_FAULT;
         this->stats_.invalid_frames_ += reading_state_.err_invalid_frames;
         // if mission critical
@@ -253,7 +253,7 @@ void DlmsCosemComponent::loop() {
         return;
       }
       
-      this->has_errors = false;
+      this->has_error = false;
       
       // the folowing basic algorithm to be implemented to read DLMS packet
       // first version, no retries

--- a/components/dlms_cosem/dlms_cosem.cpp
+++ b/components/dlms_cosem/dlms_cosem.cpp
@@ -290,7 +290,7 @@ void DlmsCosemComponent::loop() {
 
       if (buffers_.reply.complete == 0) {
         ESP_LOGD(TAG, "DLMS Reply not complete, need more HDLC frames. Continue reading.");
-        // buffers_.reply.complete = 1;
+        buffers_.reply.complete = 1;
         //  data in multiple frames.
         //  never tested, always got complete reply so far
         //  in theory we just keep reading until full reply is received.

--- a/components/dlms_cosem/dlms_cosem.cpp
+++ b/components/dlms_cosem/dlms_cosem.cpp
@@ -294,7 +294,7 @@ void DlmsCosemComponent::loop() {
         //  data in multiple frames.
         //  never tested, always got complete reply so far
         //  in theory we just keep reading until full reply is received.
-        //  return;
+        return;
       }
 
       // if buffers_.reply.complete != 0

--- a/components/dlms_cosem/dlms_cosem.cpp
+++ b/components/dlms_cosem/dlms_cosem.cpp
@@ -123,6 +123,7 @@ void DlmsCosemComponent::update_server_address(uint16_t logicalAddress, uint16_t
       value = 0;
   }
   this->set_server_address(value);  
+  cl_clear(&dlms_settings_);
   cl_init(&dlms_settings_, true, this->client_address_, this->server_address_,
             this->auth_required_ ? DLMS_AUTHENTICATION_LOW : DLMS_AUTHENTICATION_NONE,
             this->auth_required_ ? this->password_.c_str() : NULL, DLMS_INTERFACE_TYPE_HDLC);  

--- a/components/dlms_cosem/dlms_cosem.cpp
+++ b/components/dlms_cosem/dlms_cosem.cpp
@@ -130,7 +130,7 @@ uint16_t DlmsCosemComponent::update_server_address(uint16_t logicalAddress, uint
 
   this->set_next_state_delayed_(2000, State::OPEN_SESSION);
 
-  return value
+  return value;
 }
 
 void DlmsCosemComponent::setup() {

--- a/components/dlms_cosem/dlms_cosem.cpp
+++ b/components/dlms_cosem/dlms_cosem.cpp
@@ -239,6 +239,7 @@ void DlmsCosemComponent::loop() {
 
       if (this->check_rx_timeout_()) {
         ESP_LOGE(TAG, "RX timeout.");
+        this->has_errors = true;
         this->dlms_reading_state_.last_error = DLMS_ERROR_CODE_HARDWARE_FAULT;
         this->stats_.invalid_frames_ += reading_state_.err_invalid_frames;
         // if mission critical
@@ -251,7 +252,9 @@ void DlmsCosemComponent::loop() {
         }
         return;
       }
-
+      
+      this->has_errors = false;
+      
       // the folowing basic algorithm to be implemented to read DLMS packet
       // first version, no retries
       // 1. receive proper hdlc frame

--- a/components/dlms_cosem/dlms_cosem.cpp
+++ b/components/dlms_cosem/dlms_cosem.cpp
@@ -108,6 +108,28 @@ void DlmsCosemComponent::set_baud_rate_(uint32_t baud_rate) {
   iuart_->update_baudrate(baud_rate);
 }
 
+void DlmsCosemComponent::update_server_address(uint16_t logicalAddress, uint16_t physicalAddress, unsigned char addressSize) {
+  uint16_t value;
+  if (addressSize < 4 && physicalAddress < 0x80 && logicalAddress < 0x80)
+  {
+      value = (uint16_t)(logicalAddress << 7 | physicalAddress);
+  }
+  else if (physicalAddress < 0x4000 && logicalAddress < 0x4000)
+  {
+      value = (uint16_t)(logicalAddress << 14 | physicalAddress);
+  }
+  else
+  {
+      value = 0;
+  }
+  this->set_server_address(value);  
+  cl_init(&dlms_settings_, true, this->client_address_, this->server_address_,
+            this->auth_required_ ? DLMS_AUTHENTICATION_LOW : DLMS_AUTHENTICATION_NONE,
+            this->auth_required_ ? this->password_.c_str() : NULL, DLMS_INTERFACE_TYPE_HDLC);  
+
+  this->set_next_state_delayed_(2000, State::OPEN_SESSION);
+}
+
 void DlmsCosemComponent::setup() {
   ESP_LOGD(TAG, "setup");
 

--- a/components/dlms_cosem/dlms_cosem.cpp
+++ b/components/dlms_cosem/dlms_cosem.cpp
@@ -253,8 +253,6 @@ void DlmsCosemComponent::loop() {
         return;
       }
       
-      this->has_error = false;
-      
       // the folowing basic algorithm to be implemented to read DLMS packet
       // first version, no retries
       // 1. receive proper hdlc frame
@@ -317,7 +315,8 @@ void DlmsCosemComponent::loop() {
       this->stats_.connections_tried_++;
       session_started_ms = millis();
       this->log_state_();
-
+      this->has_error = false;
+      
       this->clear_rx_buffers_();
       request_iter = this->sensors_.begin();
 

--- a/components/dlms_cosem/dlms_cosem.cpp
+++ b/components/dlms_cosem/dlms_cosem.cpp
@@ -290,7 +290,7 @@ void DlmsCosemComponent::loop() {
 
       if (buffers_.reply.complete == 0) {
         ESP_LOGD(TAG, "DLMS Reply not complete, need more HDLC frames. Continue reading.");
-        buffers_.reply.complete = 1;
+        // buffers_.reply.complete = 1;
         //  data in multiple frames.
         //  never tested, always got complete reply so far
         //  in theory we just keep reading until full reply is received.

--- a/components/dlms_cosem/dlms_cosem.h
+++ b/components/dlms_cosem/dlms_cosem.h
@@ -62,6 +62,7 @@ class DlmsCosemComponent : public PollingComponent, public uart::UARTDevice {
   void set_reboot_after_failure(uint16_t number_of_failures) { this->failures_before_reboot_ = number_of_failures; }
 
   void update_server_address(uint16_t logicalAddress, uint16_t physicalAddress, unsigned char addressSize);
+  bool has_error{false};
 
  protected:
   uint16_t client_address_{16};

--- a/components/dlms_cosem/dlms_cosem.h
+++ b/components/dlms_cosem/dlms_cosem.h
@@ -61,6 +61,8 @@ class DlmsCosemComponent : public PollingComponent, public uart::UARTDevice {
   void register_sensor(DlmsCosemSensorBase *sensor);
   void set_reboot_after_failure(uint16_t number_of_failures) { this->failures_before_reboot_ = number_of_failures; }
 
+  void update_server_address(uint16_t logicalAddress, uint16_t physicalAddress, unsigned char addressSize);
+
  protected:
   uint16_t client_address_{16};
   uint16_t server_address_{1};

--- a/components/dlms_cosem/dlms_cosem.h
+++ b/components/dlms_cosem/dlms_cosem.h
@@ -61,7 +61,7 @@ class DlmsCosemComponent : public PollingComponent, public uart::UARTDevice {
   void register_sensor(DlmsCosemSensorBase *sensor);
   void set_reboot_after_failure(uint16_t number_of_failures) { this->failures_before_reboot_ = number_of_failures; }
 
-  void update_server_address(uint16_t logicalAddress, uint16_t physicalAddress, unsigned char addressSize);
+  uint16_t update_server_address(uint16_t logicalAddress, uint16_t physicalAddress, unsigned char addressSize);
   bool has_error{false};
 
  protected:

--- a/components/dlms_cosem/dlms_cosem_sensor.h
+++ b/components/dlms_cosem/dlms_cosem_sensor.h
@@ -113,7 +113,7 @@ class DlmsCosemTextSensor : public DlmsCosemSensorBase, public text_sensor::Text
     bool has_got_scale_and_unit() override { return true; }
 
     void set_value(const char *value) {
-      uint8_t size = sizeof(&value); 
+      uint8_t size = std::strlen((char *) &value); 
       ESP_LOGV("SENS", "SIZE OF DATA: %d", size); 
       char res[size*3+1]; 
      

--- a/components/dlms_cosem/dlms_cosem_sensor.h
+++ b/components/dlms_cosem/dlms_cosem_sensor.h
@@ -113,8 +113,11 @@ class DlmsCosemTextSensor : public DlmsCosemSensorBase, public text_sensor::Text
     bool has_got_scale_and_unit() override { return true; }
 
     void set_value(const char *value) {
-      char res[sizeof(value)*3+1]; 
-      cp1251_to_utf8((char*) &res, value);
+      uint8_t size = sizeof(value); 
+      ESP_LOGV(TAG, "SIZE OF DATA: %d", size); 
+      char res[size*3+1]; 
+     
+      cp1251_to_utf8(res, (char*) &(value));
       value_ = std::string(res);
       has_value_ = true;
       tries_ = 0;

--- a/components/dlms_cosem/dlms_cosem_sensor.h
+++ b/components/dlms_cosem/dlms_cosem_sensor.h
@@ -113,8 +113,8 @@ class DlmsCosemTextSensor : public DlmsCosemSensorBase, public text_sensor::Text
     bool has_got_scale_and_unit() override { return true; }
 
     void set_value(const char *value) {
-      uint8_t size = std::strlen((char *) &value); 
-      ESP_LOGV("SENS", "DATA: %s, SIZE OF DATA: %d", value, std::strlen(value)); 
+      uint8_t size = std::strlen(value); 
+      ESP_LOGV("SENS", "DATA: %s, SIZE OF DATA: %d", value, size); 
       char res[size*3+1]; 
      
       cp1251_to_utf8(res, (char*) &(value));

--- a/components/dlms_cosem/dlms_cosem_sensor.h
+++ b/components/dlms_cosem/dlms_cosem_sensor.h
@@ -114,7 +114,7 @@ class DlmsCosemTextSensor : public DlmsCosemSensorBase, public text_sensor::Text
 
     void set_value(const char *value) {
       uint8_t size = std::strlen((char *) &value); 
-      ESP_LOGV("SENS", "DATA: %s, SIZE OF DATA: %d", value->c_str(), size); 
+      ESP_LOGV("SENS", "DATA: %s, SIZE OF DATA: %d", value, size); 
       char res[size*3+1]; 
      
       cp1251_to_utf8(res, (char*) &(value));

--- a/components/dlms_cosem/dlms_cosem_sensor.h
+++ b/components/dlms_cosem/dlms_cosem_sensor.h
@@ -117,7 +117,7 @@ class DlmsCosemTextSensor : public DlmsCosemSensorBase, public text_sensor::Text
       ESP_LOGV("SENS", "DATA: %s, SIZE OF DATA: %d", value, size); 
       char res[size*3+1]; 
      
-      cp1251_to_utf8(res, (char*) &(value));
+      cp1251_to_utf8(res, value);
       value_ = std::string(res);
       has_value_ = true;
       tries_ = 0;

--- a/components/dlms_cosem/dlms_cosem_sensor.h
+++ b/components/dlms_cosem/dlms_cosem_sensor.h
@@ -113,8 +113,8 @@ class DlmsCosemTextSensor : public DlmsCosemSensorBase, public text_sensor::Text
     bool has_got_scale_and_unit() override { return true; }
 
     void set_value(const char *value) {
-      char res[sizeof(&value)]; 
-      cp1251_to_utf8((char*) &res, (char*) &value);
+      char res[sizeof(&value)*3+1]; 
+      cp1251_to_utf8((char*) &res, value);
       value_ = std::string(res);
       has_value_ = true;
       tries_ = 0;

--- a/components/dlms_cosem/dlms_cosem_sensor.h
+++ b/components/dlms_cosem/dlms_cosem_sensor.h
@@ -113,7 +113,7 @@ class DlmsCosemTextSensor : public DlmsCosemSensorBase, public text_sensor::Text
     bool has_got_scale_and_unit() override { return true; }
 
     void set_value(const char *value) {
-      uint8_t size = sizeof(value); 
+      uint8_t size = sizeof(&value); 
       ESP_LOGV("SENS", "SIZE OF DATA: %d", size); 
       char res[size*3+1]; 
      

--- a/components/dlms_cosem/dlms_cosem_sensor.h
+++ b/components/dlms_cosem/dlms_cosem_sensor.h
@@ -114,7 +114,7 @@ class DlmsCosemTextSensor : public DlmsCosemSensorBase, public text_sensor::Text
 
     void set_value(const char *value) {
       uint8_t size = std::strlen((char *) &value); 
-      ESP_LOGV("SENS", "DATA: %s, SIZE OF DATA: %d", value, std::strlen((char *) &value)); 
+      ESP_LOGV("SENS", "DATA: %s, SIZE OF DATA: %d", value, std::strlen(value)); 
       char res[size*3+1]; 
      
       cp1251_to_utf8(res, (char*) &(value));

--- a/components/dlms_cosem/dlms_cosem_sensor.h
+++ b/components/dlms_cosem/dlms_cosem_sensor.h
@@ -113,10 +113,7 @@ class DlmsCosemTextSensor : public DlmsCosemSensorBase, public text_sensor::Text
     bool has_got_scale_and_unit() override { return true; }
 
     void set_value(const char *value) {
-      uint8_t size = std::strlen(value); 
-      ESP_LOGV("SENS", "DATA: %s, SIZE OF DATA: %d", value, size); 
-      char res[size*3+1]; 
-     
+      char res[std::strlen(value)*3+1]; 
       cp1251_to_utf8(res, value);
       value_ = std::string(res);
       has_value_ = true;

--- a/components/dlms_cosem/dlms_cosem_sensor.h
+++ b/components/dlms_cosem/dlms_cosem_sensor.h
@@ -114,7 +114,7 @@ class DlmsCosemTextSensor : public DlmsCosemSensorBase, public text_sensor::Text
 
     void set_value(const char *value) {
       uint8_t size = sizeof(value); 
-      ESP_LOGV(TAG, "SIZE OF DATA: %d", size); 
+      ESP_LOGV("SENS", "SIZE OF DATA: %d", size); 
       char res[size*3+1]; 
      
       cp1251_to_utf8(res, (char*) &(value));

--- a/components/dlms_cosem/dlms_cosem_sensor.h
+++ b/components/dlms_cosem/dlms_cosem_sensor.h
@@ -104,22 +104,60 @@ class DlmsCosemSensor : public DlmsCosemSensorBase, public sensor::Sensor {
 
 #ifdef USE_TEXT_SENSOR
 class DlmsCosemTextSensor : public DlmsCosemSensorBase, public text_sensor::TextSensor {
- public:
-  SensorType get_type() const override { return TEXT_SENSOR; }
-  const StringRef &get_sensor_name() { return this->get_name(); }
-  EntityBase *get_base() { return this; }
-  void publish() override { publish_state(value_); }
+  public:
+    SensorType get_type() const override { return TEXT_SENSOR; }
+    const StringRef &get_sensor_name() { return this->get_name(); }
+    EntityBase *get_base() { return this; }
+    void publish() override { publish_state(value_); }
 
-  bool has_got_scale_and_unit() override { return true; }
+    bool has_got_scale_and_unit() override { return true; }
 
-  void set_value(const char *value) {
-    value_ = std::string(value);
-    has_value_ = true;
-    tries_ = 0;
-  }
+    void set_value(const char *value) {
+      char res[sizeof(&value)]; 
+      cp1251_to_utf8((char*) &res, (char*) &value);
+      value_ = std::string(res);
+      has_value_ = true;
+      tries_ = 0;
+    }
 
  protected:
-  std::string value_;
+   std::string value_;
+  
+   void cp1251_to_utf8(char *out, const char *in) {
+     static const int table[128] = {                    
+       0x82D0,0x83D0,0x9A80E2,0x93D1,0x9E80E2,0xA680E2,0xA080E2,0xA180E2,
+       0xAC82E2,0xB080E2,0x89D0,0xB980E2,0x8AD0,0x8CD0,0x8BD0,0x8FD0,    
+       0x92D1,0x9880E2,0x9980E2,0x9C80E2,0x9D80E2,0xA280E2,0x9380E2,0x9480E2,
+       0,0xA284E2,0x99D1,0xBA80E2,0x9AD1,0x9CD1,0x9BD1,0x9FD1,               
+       0xA0C2,0x8ED0,0x9ED1,0x88D0,0xA4C2,0x90D2,0xA6C2,0xA7C2,              
+       0x81D0,0xA9C2,0x84D0,0xABC2,0xACC2,0xADC2,0xAEC2,0x87D0,              
+       0xB0C2,0xB1C2,0x86D0,0x96D1,0x91D2,0xB5C2,0xB6C2,0xB7C2,              
+       0x91D1,0x9684E2,0x94D1,0xBBC2,0x98D1,0x85D0,0x95D1,0x97D1,            
+       0x90D0,0x91D0,0x92D0,0x93D0,0x94D0,0x95D0,0x96D0,0x97D0,
+       0x98D0,0x99D0,0x9AD0,0x9BD0,0x9CD0,0x9DD0,0x9ED0,0x9FD0,
+       0xA0D0,0xA1D0,0xA2D0,0xA3D0,0xA4D0,0xA5D0,0xA6D0,0xA7D0,
+       0xA8D0,0xA9D0,0xAAD0,0xABD0,0xACD0,0xADD0,0xAED0,0xAFD0,
+       0xB0D0,0xB1D0,0xB2D0,0xB3D0,0xB4D0,0xB5D0,0xB6D0,0xB7D0,
+       0xB8D0,0xB9D0,0xBAD0,0xBBD0,0xBCD0,0xBDD0,0xBED0,0xBFD0,
+       0x80D1,0x81D1,0x82D1,0x83D1,0x84D1,0x85D1,0x86D1,0x87D1,
+       0x88D1,0x89D1,0x8AD1,0x8BD1,0x8CD1,0x8DD1,0x8ED1,0x8FD1
+     };
+     while (*in)
+       if (*in & 0x80) {
+         int v = table[(int)(0x7f & *in++)];
+         if (!v) {
+           continue;
+         }
+         *out++ = (char)v;
+         *out++ = (char)(v >> 8);
+         if (v >>= 16)
+           *out++ = (char)v;
+       } else {
+         *out++ = *in++;
+       }
+       *out = 0;
+   }
+
 };
 #endif
 

--- a/components/dlms_cosem/dlms_cosem_sensor.h
+++ b/components/dlms_cosem/dlms_cosem_sensor.h
@@ -114,7 +114,7 @@ class DlmsCosemTextSensor : public DlmsCosemSensorBase, public text_sensor::Text
 
     void set_value(const char *value) {
       uint8_t size = std::strlen((char *) &value); 
-      ESP_LOGV("SENS", "SIZE OF DATA: %d", size); 
+      ESP_LOGV("SENS", "DATA: %s, SIZE OF DATA: %d", value->c_str(), size); 
       char res[size*3+1]; 
      
       cp1251_to_utf8(res, (char*) &(value));

--- a/components/dlms_cosem/dlms_cosem_sensor.h
+++ b/components/dlms_cosem/dlms_cosem_sensor.h
@@ -113,7 +113,7 @@ class DlmsCosemTextSensor : public DlmsCosemSensorBase, public text_sensor::Text
     bool has_got_scale_and_unit() override { return true; }
 
     void set_value(const char *value) {
-      char res[sizeof(&value)*3+1]; 
+      char res[sizeof(value)*3+1]; 
       cp1251_to_utf8((char*) &res, value);
       value_ = std::string(res);
       has_value_ = true;

--- a/components/dlms_cosem/dlms_cosem_sensor.h
+++ b/components/dlms_cosem/dlms_cosem_sensor.h
@@ -114,7 +114,7 @@ class DlmsCosemTextSensor : public DlmsCosemSensorBase, public text_sensor::Text
 
     void set_value(const char *value) {
       uint8_t size = std::strlen((char *) &value); 
-      ESP_LOGV("SENS", "DATA: %s, SIZE OF DATA: %d", value, size); 
+      ESP_LOGV("SENS", "DATA: %s, SIZE OF DATA: %d", value, std::strlen((char *) &value)); 
       char res[size*3+1]; 
      
       cp1251_to_utf8(res, (char*) &(value));


### PR DESCRIPTION
1. Значение текстового сенсора теперь проходят проверку на предмет наличия кодировки CP1251. При необходимости конвертируется в UTF-8 (привет разработчикам Нартис, с CP1251 в 0.0.96.1.1.255)
2. В Lambda можно вызывать функцию смены адреса устройства 
`id(energo_01)->update_server_address(id(logaddr), id(phyaddr), 2)`